### PR TITLE
proper handling of async postcss plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,10 +28,12 @@ module.exports = (options = { plugins: [] }) => ({
 
         const css = await readFile(sourceFullPath);
 
-        const result = await postcss(options.plugins).process(css, {
+        const lazyResult = postcss(options.plugins).process(css, {
           from: sourceFullPath,
           to: tmpFilePath,
         });
+
+        const result = await lazyResult.async();
 
         // Write result file
         await writeFile(tmpFilePath, result.css);


### PR DESCRIPTION
Before this fix build process fails if some of postcss plugins is asynchronous (simply returns a promise). In my case it was a tailwind plugin. I've traced the error and found how to fix it.


`process` method returns an instance of `LazyResult` class. Then you are accessing `css` getter, which results to attempt to run all postcss plugins synchronously which is impossible because of async logic of some plugins.

You can follow a stack-trace by these links. 
https://github.com/postcss/postcss/blob/2da5501f709862c19e7103b81ba8fb224a5793ff/lib/lazy-result.js#L163
https://github.com/postcss/postcss/blob/2da5501f709862c19e7103b81ba8fb224a5793ff/lib/lazy-result.js#L262
https://github.com/postcss/postcss/blob/2da5501f709862c19e7103b81ba8fb224a5793ff/lib/lazy-result.js#L232

[`runAsync`](https://github.com/postcss/postcss/blob/2da5501f709862c19e7103b81ba8fb224a5793ff/lib/lazy-result.js#L381) method waits for all async plugins to complete and then returns same `stringify` result that is used for `css` getter.
