### PR TITLE
refactor: remove redundant CSS resolver

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,26 +15,8 @@ export default function postCssPlugin(
   return {
     name: "postcss",
     setup(build) {
-      build.onResolve({ filter: /\.css$/, namespace: "file" }, async (args) => {
-        // Use esbuild path resolution for node_modules, tsconfig paths, etc.
-        // https://esbuild.github.io/plugins/#resolve
-        const resolution = await build.resolve(args.path, {
-          resolveDir: args.resolveDir,
-          kind: args.kind,
-        });
-
-        if (resolution.errors.length > 0) {
-          return { errors: resolution.errors };
-        }
-
-        return {
-          path: resolution.path,
-          namespace: "postcss",
-        };
-      });
-
       build.onLoad(
-        { filter: /\.css$/, namespace: "postcss" },
+        { filter: /\.css$/, namespace: "file" },
         async (args) => {
           const sourceFullPath = args.path;
           const css = await fs.readFile(sourceFullPath, "utf8");

--- a/tests/basic.js
+++ b/tests/basic.js
@@ -42,3 +42,28 @@ test("simplest case", async () => {
   assert.ok(fileContent.includes("-webkit-border-radius"));
   assert.ok(fileContent.includes("display: flex"));
 });
+
+test("processes CSS resolved through tsconfig paths", async () => {
+  const outputDir = path.join(__dirname, ".output");
+  const result = await esbuild.build({
+    stdin: {
+      contents: 'import "example.css";',
+      resolveDir: __dirname,
+      loader: "js",
+    },
+    bundle: true,
+    outfile: path.join(outputDir, "alias.js"),
+    write: false,
+    tsconfigRaw: {
+      compilerOptions: {
+        baseUrl: __dirname,
+        paths: { "example.css": ["./basic/example.css"] },
+      },
+    },
+    plugins: [postCssPlugin({ plugins: [autoPrefixerPlugin] })],
+  });
+  esbuild.stop();
+
+  const css = result.outputFiles.find((file) => file.path.endsWith(".css"));
+  assert.ok(css?.text.includes("-webkit-border-radius"));
+});


### PR DESCRIPTION
Removes the CSS onResolve callback and processes resolved CSS directly in the file namespace. Adds coverage for CSS imports resolved through tsconfig paths.\n\nTests:\n- pnpm lint\n- pnpm test