### PR TITLE
fix: support esbuild 0.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "postcss": "^8.5.6"
   },
   "peerDependencies": {
-    "esbuild": "^0.27.0"
+    "esbuild": "^0.27.0 || ^0.28.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.0.0",


### PR DESCRIPTION
Expands the esbuild peer dependency range to accept 0.28 while retaining 0.27 support.\n\nThe plugin test suite passes with the repository's esbuild 0.28.1 dev dependency.\n\nTests:\n- pnpm lint\n- pnpm test\n\nCloses #27